### PR TITLE
commented out interval occurrence zooming

### DIFF
--- a/src/components/TimelineTypes/IntervalOccurrence.tsx
+++ b/src/components/TimelineTypes/IntervalOccurrence.tsx
@@ -1,7 +1,7 @@
 import TimelineTypeInterface, {TimelineType}
   from './TimelineTypeInterface';
-import * as d3
-  from 'd3';
+// import * as d3
+//   from 'd3';
 import * as d3ScaleChromatic from 'd3-scale-chromatic';
 import assert
   from 'assert';

--- a/src/components/TimelineTypes/IntervalOccurrence.tsx
+++ b/src/components/TimelineTypes/IntervalOccurrence.tsx
@@ -16,24 +16,24 @@ export default class IntervalOccurrence extends TimelineType
    * handles zooming
    */
   applyZoom(): void {
-    d3.selectAll('.bar')
-        .attr('x', (d: any) =>
-          this.m.scale * this.m.timeScale(new Date(d[this.m.xColumn])))
-        .attr('width', (d: any) =>
-          this.m.scale * (this.m.timeScale(new Date(d[this.m.xColumn2])) -
-            this.m.timeScale(new Date(d[this.m.xColumn]))));
-
-    d3.selectAll('.xtick')
-        .attr('transform', (d: any) =>
-          `translate(${this.m.scale * this.m.timeScale(new Date(d.text))},
-            ${this.m.height})`);
-
-    d3.selectAll('.line')
-        .attr('x2', (d: any) =>
-          this.m.scale * (this.m.timeScale(new Date(d[this.m.xColumn2]))));
-    d3.selectAll('.text')
-        .attr('x', (d: any) =>
-          this.m.scale * this.m.timeScale(new Date(d[this.m.xColumn])));
+    // d3.selectAll('.bar')
+    //     .attr('x', (d: any) =>
+    //       this.m.scale * this.m.timeScale(new Date(d[this.m.xColumn])))
+    //     .attr('width', (d: any) =>
+    //       this.m.scale * (this.m.timeScale(new Date(d[this.m.xColumn2])) -
+    //         this.m.timeScale(new Date(d[this.m.xColumn]))));
+    //
+    // d3.selectAll('.xtick')
+    //     .attr('transform', (d: any) =>
+    //       `translate(${this.m.scale * this.m.timeScale(new Date(d.text))},
+    //         ${this.m.height})`);
+    //
+    // d3.selectAll('.line')
+    //     .attr('x2', (d: any) =>
+    //       this.m.scale * (this.m.timeScale(new Date(d[this.m.xColumn2]))));
+    // d3.selectAll('.text')
+    //     .attr('x', (d: any) =>
+    //       this.m.scale * this.m.timeScale(new Date(d[this.m.xColumn])));
   }
 
   /**


### PR DESCRIPTION
Effectively disabled zooming for interval occurrence. I don't think it makes a lot of sense to zoom for that feature anyways (not that it doesn't make sense) and the x-axis was zooming and not the bars so in the interest of time I have disabled it. 